### PR TITLE
Respect the 'number-columns-repeated' attribute

### DIFF
--- a/lib/ods.rb
+++ b/lib/ods.rb
@@ -152,8 +152,12 @@ class Ods
       @cols = []
       no = 'A'
       xpath('table:table-cell').each{|cell|
-        @cols << Cell.new(cell, no)
-        no.succ!
+        repeated = cell.attributes['number-columns-repeated']
+        count = (repeated && repeated.value.to_i) || 1
+        1.upto(count) do
+          @cols << Cell.new(cell, no)
+          no.succ!
+        end
       }
       @cols
     end


### PR DESCRIPTION
Apparently, when columns are duplicated within a row, the xml can have a `number-columns-repeated` attribute instead of having the value multiple times.

Without respecting this, what was returned as `row.cols` would have fewer columns than were actually present in the spreadsheet, and `row.cols[5].no` would be `:F`, but it would hold the value from column `G` in the spreadsheet.

Super confusing.

:two_hearts: 
